### PR TITLE
remove python formatting in markdown

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,7 +44,7 @@ dev = [
     "flake8==7.2.0",
     "isort==5.13.2",
     "mdformat==0.7.22",
-    "mdformat-black==0.1.1",
+
     "pre-commit==3.5.0",
     "ipykernel>=6.29.5",
 ]


### PR DESCRIPTION
Remove python formatting in markdown